### PR TITLE
Potential fix for code scanning alert no. 119: Bad HTML filtering regexp

### DIFF
--- a/wp-includes/js/tinymce/plugins/wpeditimage/plugin.js
+++ b/wp-includes/js/tinymce/plugins/wpeditimage/plugin.js
@@ -213,9 +213,12 @@ tinymce.PluginManager.add( 'wpeditimage', function( editor ) {
 					classes = ' class="' + classes + '"';
 				}
 
-				caption = caption.replace( /\r\n|\r/g, '\n' ).replace( /<[a-zA-Z0-9]+( [^<>]+)?>/g, function( a ) {
-					// No line breaks inside HTML tags.
-					return a.replace( /[\r\n\t]+/, ' ' );
+				caption = caption.replace( /\r\n|\r/g, '\n' ).replace( /<[^>]+>/g, function( a ) {
+					// Use DOMParser to safely process HTML tags.
+					var parser = new DOMParser();
+					var doc = parser.parseFromString(a, 'text/html');
+					// Extract the tag as a string without line breaks.
+					return doc.body.innerHTML.replace(/[\r\n\t]+/, ' ');
 				});
 
 				// Convert remaining line breaks to <br>.


### PR DESCRIPTION
Potential fix for [https://github.com/ShashikantSingh09/web/security/code-scanning/119](https://github.com/ShashikantSingh09/web/security/code-scanning/119)

To fix the issue, we should replace the custom regular expression with a well-tested HTML parser or sanitization library. This ensures that all edge cases are handled correctly and reduces the risk of vulnerabilities. Specifically:
1. Use a library like `DOMParser` (built into modern browsers) or a third-party library like `sanitize-html` to parse and process the HTML safely.
2. Replace the regex `<[a-zA-Z0-9]+( [^<>]+)?>` with a function that uses the chosen library to extract or manipulate HTML tags.
3. Update the relevant code in `wp-includes/js/tinymce/plugins/wpeditimage/plugin.js` to use the new approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
